### PR TITLE
fixes OSX crash

### DIFF
--- a/src/IntelHexFile.cpp
+++ b/src/IntelHexFile.cpp
@@ -58,5 +58,6 @@ ostream& operator<<(ostream& os, const IntelHexFile& rhs)
 	size_t size = rhs.addressToFileEntries.size();
 
 	os << "[Address Range: 0x" << hex << (size_t)lAddress << "-0x" << hex << (size_t)hAddress << ", Number of HexFileEntries: " << dec << size << "]";
+	return os;
 }
 

--- a/src/Program.cpp
+++ b/src/Program.cpp
@@ -50,5 +50,6 @@ ostream& operator<<(ostream& os, const Program& rhs)
 	}
 
 	os << dec << "]";
+	return os;
 }
 

--- a/src/ProgramPage.cpp
+++ b/src/ProgramPage.cpp
@@ -58,5 +58,6 @@ ostream& operator<<(ostream& os, const ProgramPage& rhs)
 	} 
 
 	os << dec << "]";
+	return os;
 }
 


### PR DESCRIPTION
Fixes OSX crash on first use of `ostream& operator<<(ostream& os, const IntelHexFile& rhs)` in `IntelHexFile.cpp`

```
zsh: trace trap  ./a.out my.hex
```